### PR TITLE
Type inference

### DIFF
--- a/src/configmypy/argparse_config.py
+++ b/src/configmypy/argparse_config.py
@@ -34,7 +34,7 @@ class ArgparseConfig:
         self.infer_types = infer_types
         self.overwrite_nested_config = overwrite_nested_config
     
-    def read_conf(self, config=None, **additional_config):
+    def read_conf(self, config=None, fuzzy=False, **additional_config):
         """
         Please note that values passed in the __init__ take precedence!
         If a config is passed, that given config (assumed to be a dict) will be updated 
@@ -44,6 +44,9 @@ class ArgparseConfig:
         ----------
         config : dict, default is None
             if not None, a dict config to update
+        fuzzy: bool, default is False
+            if True, all values, regardless of type,
+            may take the value None. 
         additional_config : dict
         
         Returns
@@ -62,7 +65,7 @@ class ArgparseConfig:
         parser = argparse.ArgumentParser(description='Read the config from the commandline.')
         for key, value in iter_nested_dict_flat(config, return_intermediate_keys=self.overwrite_nested_config):
                 # smartly infer types if 
-                inferencer = TypeInferencer(orig_type=type(value), strict=(not self.infer_types))
+                inferencer = TypeInferencer(orig_type=type(value), fuzzy=fuzzy, strict=(not self.infer_types))
 
                 parser.add_argument(f'--{key}', type=inferencer, default=value)
 

--- a/src/configmypy/argparse_config.py
+++ b/src/configmypy/argparse_config.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from .bunch import Bunch
 from .utils import iter_nested_dict_flat
 from .utils import update_nested_dict_from_flat
-
+from .type_inference import infer_numeric, infer_boolean
 
 class ArgparseConfig:
     """Read config from the command-line using argparse
@@ -62,7 +62,13 @@ class ArgparseConfig:
         parser = argparse.ArgumentParser(description='Read the config from the commandline.')
         for key, value in iter_nested_dict_flat(config, return_intermediate_keys=self.overwrite_nested_config):
             if self.infer_types and value is not None:
-                parser.add_argument(f'--{key}', type=type(value), default=value)
+                # use type inferencing callable if available, otherwise strictly infer type
+                if type(value) == int or type(value) == float:
+                    parser.add_argument(f'--{key}', type=infer_numeric, default=value)
+                elif type(value) == bool:
+                    parser.add_argument(f'--{key}', type=infer_boolean, default=value)
+                else:
+                    parser.add_argument(f'--{key}', type=type(value), default=value)
             else:
                 parser.add_argument(f'--{key}', default=value)
 

--- a/src/configmypy/argparse_config.py
+++ b/src/configmypy/argparse_config.py
@@ -44,9 +44,12 @@ class ArgparseConfig:
         ----------
         config : dict, default is None
             if not None, a dict config to update
-        fuzzy: bool, default is False
-            if True, all values, regardless of type,
+        infer_types: bool, default is False
+            if True, uses custom type handling
+            where all values, regardless of type,
             may take the value None. 
+            If false, uses default argparse
+            typecasting
         additional_config : dict
         
         Returns
@@ -64,8 +67,9 @@ class ArgparseConfig:
         
         parser = argparse.ArgumentParser(description='Read the config from the commandline.')
         for key, value in iter_nested_dict_flat(config, return_intermediate_keys=self.overwrite_nested_config):
-                # smartly infer types if 
-                inferencer = TypeInferencer(orig_type=type(value), fuzzy=fuzzy, strict=(not self.infer_types))
+                # smartly infer types if infer_types is turned on 
+                # otherwise force default typecasting
+                inferencer = TypeInferencer(orig_type=type(value), strict=(not self.infer_types))
 
                 parser.add_argument(f'--{key}', type=inferencer, default=value)
 

--- a/src/configmypy/argparse_config.py
+++ b/src/configmypy/argparse_config.py
@@ -1,5 +1,6 @@
 import argparse
 from copy import deepcopy
+from ctypes import ArgumentError
 from .bunch import Bunch
 from .utils import iter_nested_dict_flat
 from .utils import update_nested_dict_from_flat
@@ -12,8 +13,10 @@ class ArgparseConfig:
     
     Parameters
     ----------
-    infer_types : bool, default is True
-        if True, use type(value) to indicate expected type
+    infer_types : False or literal['fuzzy', 'strict']
+        if False, use python's typecasting from type(value) to indicate expected type
+        if fuzzy, use custom type handling and allow all types to take values of None
+        if strict, use custom type handling but do not allow passing bool or None to other types.
 
     overwrite_nested_config : bool, default is True
         if True, users can set values at different levels of nesting
@@ -29,12 +32,15 @@ class ArgparseConfig:
     **additional_config : dict
         key, values to read from command-line and pass on to the next config
     """
-    def __init__(self, infer_types=True, overwrite_nested_config=False, **additional_config):
+    def __init__(self, infer_types=False, overwrite_nested_config=False, **additional_config):
         self.additional_config = Bunch(additional_config)
-        self.infer_types = infer_types
+        if infer_types in [False, "fuzzy", "strict"]:
+            self.infer_types = infer_types
+        else:
+            raise ArgumentError("Error: infer_types only takes values False, \'fuzzy\', \'strict\'")
         self.overwrite_nested_config = overwrite_nested_config
     
-    def read_conf(self, config=None, fuzzy=False, **additional_config):
+    def read_conf(self, config=None, **additional_config):
         """
         Please note that values passed in the __init__ take precedence!
         If a config is passed, that given config (assumed to be a dict) will be updated 
@@ -69,9 +75,17 @@ class ArgparseConfig:
         for key, value in iter_nested_dict_flat(config, return_intermediate_keys=self.overwrite_nested_config):
                 # smartly infer types if infer_types is turned on 
                 # otherwise force default typecasting
-                inferencer = TypeInferencer(orig_type=type(value), strict=(not self.infer_types))
+                if self.infer_types:
+                    if self.infer_types == 'strict':
+                        strict=True
+                    elif  self.infer_types == 'fuzzy':
+                        strict=False
 
-                parser.add_argument(f'--{key}', type=inferencer, default=value)
+                    type_inferencer = TypeInferencer(orig_type=type(value), strict=strict)
+                else:
+                    type_inferencer = type(value)
+
+                parser.add_argument(f'--{key}', type=type_inferencer, default=value)
 
         args = parser.parse_args()
         self.config = Bunch(args.__dict__)        

--- a/src/configmypy/argparse_config.py
+++ b/src/configmypy/argparse_config.py
@@ -32,7 +32,7 @@ class ArgparseConfig:
     **additional_config : dict
         key, values to read from command-line and pass on to the next config
     """
-    def __init__(self, infer_types=False, overwrite_nested_config=False, **additional_config):
+    def __init__(self, infer_types="fuzzy", overwrite_nested_config=False, **additional_config):
         self.additional_config = Bunch(additional_config)
         if infer_types in [False, "fuzzy", "strict"]:
             self.infer_types = infer_types

--- a/src/configmypy/tests/test_argparse_config.py
+++ b/src/configmypy/tests/test_argparse_config.py
@@ -12,7 +12,7 @@ TEST_CONFIG_DICT = {
 def test_ArgparseConfig(monkeypatch):
     monkeypatch.setattr("sys.argv", ['test', '--data.batch_size', '24'])
     config = Bunch(TEST_CONFIG_DICT['default'])
-    parser = ArgparseConfig(infer_types=True)
+    parser = ArgparseConfig(infer_types='fuzzy')
     args, kwargs = parser.read_conf(config)
     config.data.batch_size = 24
     assert config == args
@@ -24,7 +24,7 @@ def test_ArgparseConfig(monkeypatch):
                                      '--opt.regularizer', 'False',
                                      '--config_name', 'test'])
     config = Bunch(TEST_CONFIG_DICT['default'])
-    parser = ArgparseConfig(infer_types=True, config_name=None)
+    parser = ArgparseConfig(infer_types='fuzzy', config_name=None)
     args, kwargs = parser.read_conf(config)
     config.data.batch_size = 24
     assert args.data.test_resolutions == [8, None]
@@ -38,7 +38,7 @@ def test_ArgparseConfig(monkeypatch):
     # Test overwriting entire nested argument
     monkeypatch.setattr("sys.argv", ['test', '--data', '0', '--config_name', 'test'])
     config = Bunch(TEST_CONFIG_DICT['default'])
-    parser = ArgparseConfig(infer_types=True, config_name=None, overwrite_nested_config=True)
+    parser = ArgparseConfig(infer_types='fuzzy', config_name=None, overwrite_nested_config=True)
     args, kwargs = parser.read_conf(config)
     config['data'] = 0
     assert config == args

--- a/src/configmypy/tests/test_argparse_config.py
+++ b/src/configmypy/tests/test_argparse_config.py
@@ -3,9 +3,9 @@ from ..bunch import Bunch
 
 
 TEST_CONFIG_DICT = {
-        'default': {'opt': {'optimizer': 'adam', 'lr': 0.1, 'regularizer': True},
+        'default': {'opt': {'optimizer': 'adam', 'lr': 1, 'regularizer': True},
               'data': {'dataset': 'ns', 'batch_size': 12, 'test_resolutions':[16,32]}},
-  'test': {'opt': {'optimizer': 'SGD'}}
+        'test': {'opt': {'optimizer': 'SGD'}}
 }
 
 
@@ -18,20 +18,24 @@ def test_ArgparseConfig(monkeypatch):
     assert config == args
     assert kwargs == {}
     
-    # test ability to infer None and iterables
+    # test ability to infer None, int-->float and iterables
     monkeypatch.setattr("sys.argv", ['test', '--data.batch_size', '24',\
-                                    '--data.test_resolutions', '[8, None]',
-                                     '--opt.regularizer', 'False',
+                                    '--data.test_resolutions', '[8, None]',\
+                                     '--opt.lr', '0.01',\
+                                     '--opt.regularizer', 'False',\
                                      '--config_name', 'test'])
     config = Bunch(TEST_CONFIG_DICT['default'])
     parser = ArgparseConfig(infer_types='fuzzy', config_name=None)
     args, kwargs = parser.read_conf(config)
     config.data.batch_size = 24
+    assert args.opt.lr == 0.01 # ensure no casting to int
     assert args.data.test_resolutions == [8, None]
     assert not args.opt.regularizer #boolean False, not 'False'
 
+
     args.data.test_resolutions = [16,32]
     args.opt.regularizer = True
+    args.opt.lr = 1
     assert config == args
     assert kwargs == Bunch(dict(config_name='test'))
 

--- a/src/configmypy/tests/test_argparse_config.py
+++ b/src/configmypy/tests/test_argparse_config.py
@@ -3,8 +3,8 @@ from ..bunch import Bunch
 
 
 TEST_CONFIG_DICT = {
-  'default': {'opt': {'optimizer': 'adam', 'lr': 0.1},
-              'data': {'dataset': 'ns', 'batch_size': 12}},
+        'default': {'opt': {'optimizer': 'adam', 'lr': 0.1, 'regularizer': True},
+              'data': {'dataset': 'ns', 'batch_size': 12, 'test_resolutions':[16,32]}},
   'test': {'opt': {'optimizer': 'SGD'}}
 }
 
@@ -17,12 +17,21 @@ def test_ArgparseConfig(monkeypatch):
     config.data.batch_size = 24
     assert config == args
     assert kwargs == {}
-
-    monkeypatch.setattr("sys.argv", ['test', '--data.batch_size', '24', '--config_name', 'test'])
+    
+    # test ability to infer None and iterables
+    monkeypatch.setattr("sys.argv", ['test', '--data.batch_size', '24',\
+                                    '--data.test_resolutions', '[8, None]',
+                                     '--opt.regularizer', 'False',
+                                     '--config_name', 'test'])
     config = Bunch(TEST_CONFIG_DICT['default'])
     parser = ArgparseConfig(infer_types=True, config_name=None)
     args, kwargs = parser.read_conf(config)
     config.data.batch_size = 24
+    assert args.data.test_resolutions == [8, None]
+    assert not args.opt.regularizer #boolean False, not 'False'
+
+    args.data.test_resolutions = [16,32]
+    args.opt.regularizer = True
     assert config == args
     assert kwargs == Bunch(dict(config_name='test'))
 

--- a/src/configmypy/type_inference.py
+++ b/src/configmypy/type_inference.py
@@ -114,7 +114,6 @@ class TypeInferencer(object):
         var: original variable (any type)
 
         """
-        print(f"{self.orig_type=} {var=}")
         if self.orig_type == bool:
             return infer_boolean(var, self.strict)
         elif self.orig_type == float or self.orig_type == int:

--- a/src/configmypy/type_inference.py
+++ b/src/configmypy/type_inference.py
@@ -1,9 +1,19 @@
 # Infer types of argparse arguments intelligently
 
 from argparse import ArgumentTypeError
+from typing import Callable
 
 
 def infer_boolean(var):
+    """
+    accept argparse inputs of string, correctly
+    convert into bools. Without this behavior, 
+    bool('False') becomes True by default.
+
+    Parameters
+    ----------
+    var: input from parser.args
+    """
     if var.lower() == 'true':
         return True
     elif var.lower() == 'false':
@@ -12,11 +22,40 @@ def infer_boolean(var):
         raise ArgumentTypeError()
 
 def infer_numeric(var):
-    # infer float
+    # infer numeric values using simple hierarchy
+    # int if possible -> float -> NoneType
     if '.' in list(var):
         return float(var)
     elif var.isnumeric():
         return int(var)
+    elif var.lower() == 'none' or var.lower() == 'false':
+        return None
     else:
         raise ArgumentTypeError()
+
+
+class TypeInferencer(object):
+    def __init__(self, orig_type: Callable, strict: bool=False):
+        """
+        TypeInferencer mediates between argparse
+        and ArgparseConfig
+        
+        """
+        self.orig_type = orig_type
+        self.strict = strict
+
+    def __call__(self, var):
+        if self.strict:
+            return self.orig_type(var)
+        else:
+            if orig_type == bool:
+                return infer_boolean(var)
+            elif orig_type == float or orig_type == int:
+                return infer_numeric(var)
+            else:
+                # add infer_list, etc?
+                return self.orig_type(var)
+
+
+
 

--- a/src/configmypy/type_inference.py
+++ b/src/configmypy/type_inference.py
@@ -83,6 +83,7 @@ class TypeInferencer(object):
         
         orig_type: Callable type
             type of original var from config
+            cannot be NoneType - defaults to infer_str
         strict: bool, default True
             whether to use type inferencing. If False,
             default to simply applying default type converter.
@@ -95,7 +96,10 @@ class TypeInferencer(object):
             the allowed types. Otherwise default to str. 
 
         """
-        self.orig_type = orig_type
+        if orig_type == type(None):
+            self.orig_type = infer_str
+        else:
+            self.orig_type = orig_type
         self.strict = strict
 
     def __call__(self, var):
@@ -104,6 +108,7 @@ class TypeInferencer(object):
         var: original variable (any type)
 
         """
+        print(f"{self.orig_type=} {var=}")
         if self.orig_type == bool:
             return infer_boolean(var, self.strict)
         elif self.orig_type == float or self.orig_type == int:

--- a/src/configmypy/type_inference.py
+++ b/src/configmypy/type_inference.py
@@ -1,0 +1,22 @@
+# Infer types of argparse arguments intelligently
+
+from argparse import ArgumentTypeError
+
+
+def infer_boolean(var):
+    if var.lower() == 'true':
+        return True
+    elif var.lower() == 'false':
+        return False
+    else:
+        raise ArgumentTypeError()
+
+def infer_numeric(var):
+    # infer float
+    if '.' in list(var):
+        return float(var)
+    elif var.isnumeric():
+        return int(var)
+    else:
+        raise ArgumentTypeError()
+

--- a/src/configmypy/type_inference.py
+++ b/src/configmypy/type_inference.py
@@ -54,7 +54,26 @@ def infer_str(var, strict:bool=True):
         return None
     else:
         return str(var)
-        
+
+def infer_iterable(var, iterable_type: Callable, strict: bool=True):
+    """
+    infer value of an iterable with expected type List[type] or Tuple[type]
+
+    var: str 
+        input to argparse
+    iterable_type: Callable
+        function to apply on contents of iterable
+    """
+    # unpack outer list, apply recursively, return list or tuple of inner
+    if var[0] == "[" and var[-1] == "]":
+        return infer_iterable(var[1:-1], iterable_type, strict)
+    elif var[0] == "(" and var [-1] == ")":
+        return tuple(infer_iterable(var[1:-1], iterable_type, strict))
+    else:
+        iterable_entries = var.split(",")
+        return [iterable_type(x,strict) for x in iterable_entries]
+
+
 
 class TypeInferencer(object):
     def __init__(self, orig_type: Callable, strict: bool=True):


### PR DESCRIPTION
Argparse directly takes custom Callable functions as a type. 

This PR:
- creates a custom type inferencer class
- supports strict and loose typing (e.g. inferring a numeric value of None)
- supports passing iterables of any type into the command line