### PR TITLE
Fix argparse config type inferencer

### DIFF
--- a/src/configmypy/argparse_config.py
+++ b/src/configmypy/argparse_config.py
@@ -83,7 +83,7 @@ class ArgparseConfig:
                         strict=True
                     elif  self.infer_types == 'fuzzy':
                         strict=False
-
+                    print(f"creating inferencer for {key} of type {type(value)}")
                     type_inferencer = TypeInferencer(orig_type=type(value), strict=strict)
                 else:
                     type_inferencer = type(value)

--- a/src/configmypy/tests/test_argparse_config.py
+++ b/src/configmypy/tests/test_argparse_config.py
@@ -10,12 +10,17 @@ TEST_CONFIG_DICT = {
 
 
 def test_ArgparseConfig(monkeypatch):
-    monkeypatch.setattr("sys.argv", ['test', '--data.batch_size', '24'])
+    monkeypatch.setattr("sys.argv", ['test', '--data.batch_size', '24',\
+                                            '--data.test_resolutions', '[16]'])
     config = Bunch(TEST_CONFIG_DICT['default'])
     parser = ArgparseConfig(infer_types='fuzzy')
     args, kwargs = parser.read_conf(config)
+    assert args.data.test_resolutions == [16]
     config.data.batch_size = 24
+    config.data.test_resolutions = [16]
     assert config == args
+    # reset config data test_res
+    config.data.test_resolutions = [16,32]
     assert kwargs == {}
     
     # test ability to infer None, int-->float and iterables

--- a/src/configmypy/tests/test_pipeline_config.py
+++ b/src/configmypy/tests/test_pipeline_config.py
@@ -12,6 +12,10 @@ default:
   data:
     dataset: 'ns'
     batch_size: 12
+    test_batch_sizes: [16,32]
+  other:
+    int_to_float: 1
+    float_to_none: 0.5
     
 test:
   opt:
@@ -20,7 +24,8 @@ test:
 
 TEST_CONFIG_DICT = {
   'default': {'opt': {'optimizer': 'adam', 'lr': 0.1},
-              'data': {'dataset': 'ns', 'batch_size': 12}},
+              'data': {'dataset': 'ns', 'batch_size': 12, 'test_batch_sizes':[16,16]},
+              'other': {'int_to_float': 1, 'float_to_none': 0.5}},
   'test': {'opt': {'optimizer': 'SGD'}}
 }
 
@@ -28,15 +33,22 @@ TEST_CONFIG_DICT = {
 def test_ConfigPipeline(mocker, monkeypatch):
     """"Test for ConfigPipeline"""
     mocker.patch("builtins.open", mocker.mock_open(read_data=TEST_CONFIG_FILE))
-    monkeypatch.setattr("sys.argv", ['test', '--data.batch_size', '24', '--config_file', 'config.yaml', '--config_name', 'test'])
+    monkeypatch.setattr("sys.argv", ['test', '--data.batch_size', '24', \
+                                     '--data.test_batch_sizes', '[16,16]',\
+                                     '--other.int_to_float', '0.05', \
+                                     '--other.float_to_none', 'None', \
+                                     '--config_file', 'config.yaml', \
+                                      '--config_name', 'test'])
 
     true_config = Bunch(TEST_CONFIG_DICT['default'])
     true_config.data.batch_size = 24
     true_config.opt.optimizer = 'SGD'
+    true_config.other.int_to_float = 0.05
+    true_config.other.float_to_none = None
 
     pipe = ConfigPipeline([
                             YamlConfig('./config.yaml', config_name='default'),
-                            ArgparseConfig(config_file=None, config_name=None),
+                            ArgparseConfig(config_file=None, config_name=None, infer_types='fuzzy'),
                             YamlConfig()
                             ])
     config = pipe.read_conf()

--- a/src/configmypy/type_inference.py
+++ b/src/configmypy/type_inference.py
@@ -4,6 +4,9 @@ from argparse import ArgumentTypeError
 from ast import literal_eval
 from typing import Callable
 
+# import custom Yaml types to handle sequences
+from ruamel.yaml import CommentedSeq, CommentedMap
+
 
 def infer_boolean(var, strict: bool=True):
     """
@@ -118,7 +121,7 @@ class TypeInferencer(object):
             return infer_boolean(var, self.strict)
         elif self.orig_type == float or self.orig_type == int:
             return infer_numeric(var, self.strict)
-        elif self.orig_type == tuple or self.orig_type == list:
+        elif self.orig_type == tuple or self.orig_type == list or self.orig_type == CommentedMap or self.orig_type == CommentedSeq:
             return infer_iterable(var, None, self.strict)
         else:
             if self.strict:

--- a/src/configmypy/type_inference.py
+++ b/src/configmypy/type_inference.py
@@ -6,6 +6,9 @@ from typing import Callable
 
 # import custom Yaml types to handle sequences
 from ruamel.yaml import CommentedSeq, CommentedMap
+from ruamel.yaml.scalarfloat import ScalarFloat
+from ruamel.yaml.scalarint import ScalarInt
+from ruamel.yaml.scalarbool import ScalarBoolean
 
 
 def infer_boolean(var, strict: bool=True):
@@ -117,9 +120,9 @@ class TypeInferencer(object):
         var: original variable (any type)
 
         """
-        if self.orig_type == bool:
+        if self.orig_type == bool or self.orig_type == ScalarBoolean:
             return infer_boolean(var, self.strict)
-        elif self.orig_type == float or self.orig_type == int:
+        elif self.orig_type == float or self.orig_type == int or self.orig_type == ScalarFloat or self.orig_type == ScalarInt:
             return infer_numeric(var, self.strict)
         elif self.orig_type == tuple or self.orig_type == list or self.orig_type == CommentedMap or self.orig_type == CommentedSeq:
             return infer_iterable(var, None, self.strict)


### PR DESCRIPTION
Adds handling for custom `ruamel.yaml` types in a config pipeline.